### PR TITLE
Docker Update, main branch (2024.12.26.)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,11 @@
+# ATOMKI Common Data Acquisition
+#
+# (c) 2024 ATOMKI, Debrecen, Hungary
+#
+# Apache License Version 2.0
 
 # Use the CI's image.
-FROM registry.gitlab.com/atomki-nuclear-phys/cda/reference-os:ubuntu-16.04-v1
+FROM krasznaa/cda-build:ubuntu-16.04-v2
 
 # Set up the command to run when starting the image.
 CMD /bin/bash

--- a/docker/ubuntu-12.04/Dockerfile
+++ b/docker/ubuntu-12.04/Dockerfile
@@ -1,3 +1,9 @@
+# ATOMKI Common Data Acquisition
+#
+# (c) 2024 ATOMKI, Debrecen, Hungary
+#
+# Apache License Version 2.0
+
 #
 # Ubuntu 12.04 image for building CDA on top of.
 #
@@ -16,7 +22,16 @@ RUN sed -i -e "s/archive.ubuntu.com/old-releases.ubuntu.com/g" \
 
 # Install the required packages:
 RUN apt-get update && apt-get -y install gcc g++ libqt4-dev make wget \
-    cernlib-base-dev cernlib-core-dev libncurses5-dev && apt-get clean
+    cernlib-base-dev cernlib-core-dev libncurses5-dev libexpat1-dev gettext \
+    libperl-dev libcurl4-openssl-dev libssl-dev \
+    && apt-get clean
+
+# Install a newer version of Git than what's available in this old release.
+RUN wget --no-check-certificate \
+    https://www.kernel.org/pub/software/scm/git/git-1.8.5.6.tar.gz \
+    && tar -xvf git-*.tar.gz && cd git-*/ && \
+    make prefix=/usr/local all && make prefix=/usr/local install && \
+    cd .. && rm -rf git-*
 
 # Install a newer version of CMake than what's available in this
 # old release:

--- a/docker/ubuntu-16.04/Dockerfile
+++ b/docker/ubuntu-16.04/Dockerfile
@@ -1,3 +1,9 @@
+# ATOMKI Common Data Acquisition
+#
+# (c) 2024 ATOMKI, Debrecen, Hungary
+#
+# Apache License Version 2.0
+
 #
 # Ubuntu 16.04 image for building CDA on top of.
 #
@@ -12,7 +18,7 @@ WORKDIR /root
 # Install the required packages:
 RUN apt-get update && apt-get -y install gcc g++ qt5-default \
     qttools5-dev-tools make wget doxygen graphviz cernlib-base-dev \
-    cernlib-core-dev libncurses5-dev \
+    cernlib-core-dev libncurses5-dev git \
     && apt-get clean
 
 # Install a newer version of CMake than what's available in this


### PR DESCRIPTION
Switched back to [DockerHub](https://hub.docker.com/) with the images, and added Git to them. The latter is needed both for using them with VSCode, and to make it possible to use GitHub's CI with these old images.