### PR TITLE
HBOOK Update, main branch (2025.01.02.)

### DIFF
--- a/apps/cda-hbook-writer/Crate.h
+++ b/apps/cda-hbook-writer/Crate.h
@@ -1,10 +1,12 @@
-// Dear emacs, this is -*- c++ -*-
-// $Id$
+//
+// ATOMKI Common Data Acquisition
+//
+// (c) 2008-2024 ATOMKI, Debrecen, Hungary
+//
+// Apache License Version 2.0
+//
 #ifndef CDA_APPS_CDA_HBOOK_WRITER_CRATE_H
 #define CDA_APPS_CDA_HBOOK_WRITER_CRATE_H
-
-// Qt include(s):
-#include <QtCore/QString>
 
 // CDA include(s):
 #include "cernlib/NTupleMgr.h"
@@ -12,6 +14,9 @@
 #include "device/ICernlibDisk.h"
 #include "event/Event.h"
 #include "msg/Logger.h"
+
+// Qt include(s):
+#include <QtCore/QString>
 
 /**
  *  @short Namespace for the classes used in cda-hbook-writer
@@ -21,9 +26,6 @@
  *         for the application.
  *
  * @author Attila Krasznahorkay <Attila.Krasznahorkay@cern.ch>
- *
- * $Revision$
- * $Date$
  */
 namespace hbook {
 
@@ -35,9 +37,6 @@ namespace hbook {
  *         the CERNLIB libraries.
  *
  * @author Attila Krasznahorkay <Attila.Krasznahorkay@cern.ch>
- *
- * $Revision$
- * $Date$
  */
 class Crate : public dev::Crate<dev::ICernlibDisk> {
 
@@ -46,19 +45,17 @@ class Crate : public dev::Crate<dev::ICernlibDisk> {
 public:
    /// Default constructor
    Crate();
-   /// Destructor, closing the output file
-   ~Crate();
 
    /// Create and initialize the output file
-   bool initialize(const QString& fileName);
+   StatusCode initialize(const QString& fileName);
    /// Write one event to the output file
-   bool writeEvent(const ev::Event& event);
+   StatusCode writeEvent(const ev::Event& event);
    /// Finalize and close the output file
-   bool finalize();
+   StatusCode finalize();
 
 private:
-   cernlib::NTupleMgr m_nmgr;     ///< Object actually handling the ntuple
-   mutable msg::Logger m_logger;  ///< Logger object for the class
+   cernlib::NTupleMgr m_nmgr;  ///< Object actually handling the ntuple
+   msg::Logger m_logger;       ///< Logger object for the class
 
 };  // class Crate
 

--- a/apps/cda-hbook-writer/FileWriter.h
+++ b/apps/cda-hbook-writer/FileWriter.h
@@ -1,13 +1,18 @@
-// Dear emacs, this is -*- c++ -*-
-// $Id$
+//
+// ATOMKI Common Data Acquisition
+//
+// (c) 2008-2024 ATOMKI, Debrecen, Hungary
+//
+// Apache License Version 2.0
+//
 #ifndef CDA_APPS_CDA_HBOOK_WRITER_FILEWRITER_H
 #define CDA_APPS_CDA_HBOOK_WRITER_FILEWRITER_H
 
-// Qt include(s):
-#include <QtCore/QThread>
-
 // CDA include(s):
 #include "msg/Logger.h"
+
+// Qt include(s):
+#include <QThread>
 
 // Forward declaration(s):
 namespace ev {
@@ -27,9 +32,6 @@ class Crate;
  *         and to monitor its status.
  *
  * @author Attila Krasznahorkay <Attila.Krasznahorkay@cern.ch>
- *
- * $Revision$
- * $Date$
  */
 class FileWriter : public QThread {
 
@@ -58,7 +60,7 @@ private:
    Crate& m_crate;               ///< Pre-configured CAMAC crate object
    quint32 m_processedEvents;    ///< Number of processed events
 
-   mutable msg::Logger m_logger;  ///< Logger object for the class
+   msg::Logger m_logger;  ///< Logger object for the class
 
 };  // class FileWriter
 

--- a/apps/cda-hbook-writer/main.cxx
+++ b/apps/cda-hbook-writer/main.cxx
@@ -359,7 +359,7 @@ void shutDown(int) {
    g_fwriter->stopProcessing();
 
    // Close the current output file:
-   g_crate->finalize();
+   g_crate->finalize().ignore();
 
    g_logger << msg::INFO
             << qApp->translate("cda-hbook-writer",

--- a/core/cernlib/NTupleMgr.h
+++ b/core/cernlib/NTupleMgr.h
@@ -1,17 +1,23 @@
-// Dear emacs, this is -*- c++ -*-
+//
+// ATOMKI Common Data Acquisition
+//
+// (c) 2008-2024 ATOMKI, Debrecen, Hungary
+//
+// Apache License Version 2.0
+//
 #ifndef CDA_CORE_CERNLIB_NTUPLEMGR_H
 #define CDA_CORE_CERNLIB_NTUPLEMGR_H
 
-// STL include(s):
-#include <vector>
+// CDA include(s):
+#include "../common/StatusCode.h"
+#include "../msg/Logger.h"
 
 // Qt include(s):
 #include <QCoreApplication>
 #include <QString>
 
-// CDA include(s):
-#include "../common/Export.h"
-#include "../msg/Logger.h"
+// STL include(s):
+#include <vector>
 
 /**
  *  @short Namespace for the CERNLIB interface classes
@@ -38,7 +44,7 @@ namespace cernlib {
  *
  * @author Attila Krasznahorkay <Attila.Krasznahorkay@cern.ch>
  */
-class CDACORE_EXPORT NTupleMgr {
+class NTupleMgr {
 
    // To get the tr() function:
    Q_DECLARE_TR_FUNCTIONS(cernlib::NTupleMgr)
@@ -52,17 +58,14 @@ public:
    /// Add a new variable to the ntuple
    int addVar(const QString& name);
    /// Open an HBOOK file
-   bool openFile(const QString& fileName);
+   StatusCode openFile(const QString& fileName);
    /// Close the currently open HBOOK file
    void closeFile();
 
    /// Set the value of a variable in the current event
-   bool setVar(int index, float value);
+   StatusCode setVar(int index, float value);
    /// Add the event to the ntuple
-   void saveEvent();
-
-   /// Clear all settings of the object
-   void clear();
+   StatusCode saveEvent();
 
    static const int HFILE_ID;   ///< ID of the HBOOK file
    static const int NTUPLE_ID;  ///< ID of the ntuple
@@ -71,11 +74,11 @@ private:
    bool m_fileOpen;  ///< Status of the output file
 
    std::vector<QString> m_varNames;  ///< NTuple variable names
-   float* m_variables;               ///< NTuple event buffer
+   std::vector<float> m_variables;   ///< NTuple event buffer
 
    int m_events;  ///< Number of events written to the ntuple
 
-   mutable msg::Logger m_logger;  ///< Message logging object
+   msg::Logger m_logger;  ///< Message logging object
 
 };  // class NTupleMgr
 


### PR DESCRIPTION
Updated the HBOOK writing code a little. Attempting (but failing...) to fix the writing of such files on the Ubuntu 16.04 (32 bit) DAQ machine...

Introduced the use of `StatusCode` in a number of places, while making the memory management in `hbook::NTupleMgr` just a very little safer.