### PR TITLE
Modernize msg::TextView, main branch (2025.01.04.)

### DIFF
--- a/gui/msg/TextView.cxx
+++ b/gui/msg/TextView.cxx
@@ -1,65 +1,93 @@
+//
+// ATOMKI Common Data Acquisition
+//
+// (c) 2008-2025 ATOMKI, Debrecen, Hungary
+//
+// Apache License Version 2.0
+//
 
-// Qt include(s):
-#include <QStackedLayout>
-#include <QTextDocument>
-#include <QTextEdit>
-#include <QtCore/QString>
+// Local include(s):
+#include "TextView.h"
 
 // CDA include(s):
 #include "msg/Message.h"
 #include "msg/TextStream.h"
 
-// Local include(s):
-#include "TextView.h"
+// Qt include(s):
+#include <QStackedLayout>
+#include <QString>
+#include <QTextDocument>
+#include <QTextEdit>
+
+// System include(s).
+#include <utility>
+
+namespace {
+
+/// Decide whether a dark theme is active
+bool shouldApplyDarkTheme() {
+   const QPalette defaultPalette;
+   return defaultPalette.color(QPalette::WindowText).lightness() >
+          defaultPalette.color(QPalette::Window).lightness();
+}
+
+}  // namespace
 
 namespace msg {
+
+struct TextView::Impl {
+
+   /// Constructor
+   Impl(QWidget& parent) : m_layout{&parent}, m_edit{&parent} {
+
+      m_layout.addWidget(&m_edit);
+   }
+
+   /// The layout used by the widget
+   QStackedLayout m_layout;
+   /// The text field showing the messages
+   QTextEdit m_edit;
+
+   /// Map to set the foreground and background color of the messages
+   std::map<Level, std::pair<QColor, QColor> > m_levelColor;
+
+   /// Level under which messages are not shown
+   Level m_minShownLevel;
+};
 
 /**
  * The constructor creates the QTextEdit object used to present the
  * messages and sets it up to show the messages in a reasonable way.
  */
 TextView::TextView(QWidget* parent, Qt::WindowFlags flags)
-    : QWidget(parent, flags), m_minShownLevel(VERBOSE) {
+    : QWidget(parent, flags), m_impl{new Impl{*this}} {
 
-   // Init the internal maps:
-   initMaps();
+   // Set up the text view widget.
+   m_impl->m_edit.setReadOnly(true);
+   m_impl->m_edit.setFontFamily("courier");
+   m_impl->m_edit.setLineWrapMode(QTextEdit::NoWrap);
+   m_impl->m_edit.document()->setMaximumBlockCount(100);
 
-   // We don't really need a layout, it's just here to make sure the
-   // text edit widget takes up all available space.
-   m_layout = new QStackedLayout(this);
-
-   // Create the main widget. It is configured to use fixed-width fonts
-   // and to only show a maximum of a 100 messages at a time. (The latter
-   // can be changed by the code using the class.)
-   m_edit = new QTextEdit();
-   m_edit->setMinimumSize(450, 100);
-   m_edit->setMaximumSize(20000, 20000);
-   m_edit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-   m_edit->setReadOnly(true);
-   m_edit->setFontFamily("courier");
-#ifdef Q_OS_DARWIN
-   //      m_edit->setFontPointSize( 12 );
-#else
-   m_edit->setFontPointSize(10);
-#endif  // Q_OS_MAC
-   m_edit->setLineWrapMode(QTextEdit::NoWrap);
-   m_edit->document()->setMaximumBlockCount(100);
-
-   m_layout->addWidget(m_edit);
+   // Set the colour of the different messages.
+   m_impl->m_levelColor[VERBOSE] = {QColor(Qt::cyan), QColor(Qt::black)};
+   m_impl->m_levelColor[DEBUG] = {QColor(Qt::blue), QColor(Qt::white)};
+   m_impl->m_levelColor[INFO] = {
+       m_impl->m_edit.textBackgroundColor(),
+       shouldApplyDarkTheme() ? QColor(Qt::white) : QColor(Qt::black)};
+   m_impl->m_levelColor[WARNING] = {QColor(Qt::yellow), QColor(Qt::black)};
+   m_impl->m_levelColor[ERROR] = {QColor(Qt::red), QColor(Qt::white)};
+   m_impl->m_levelColor[FATAL] = {QColor(Qt::darkRed), QColor(Qt::white)};
+   m_impl->m_levelColor[ALWAYS] = {QColor(Qt::lightGray), QColor(Qt::black)};
 }
 
-TextView::~TextView() {
-
-   delete m_edit;
-   delete m_layout;
-}
+TextView::~TextView() {}
 
 /**
  * @returns The maximum number of messages that can be shown
  */
 int TextView::getMaximumMessageCount() const {
 
-   return m_edit->document()->maximumBlockCount();
+   return m_impl->m_edit.document()->maximumBlockCount();
 }
 
 /**
@@ -67,7 +95,7 @@ int TextView::getMaximumMessageCount() const {
  */
 Level TextView::getMinimumShownLevel() const {
 
-   return m_minShownLevel;
+   return m_impl->m_minShownLevel;
 }
 
 /**
@@ -82,8 +110,9 @@ void TextView::addMessage(const Message& message) {
    //
    // Return right away if the message should not be shown:
    //
-   if (message.getLevel() < m_minShownLevel)
+   if (message.getLevel() < m_impl->m_minShownLevel) {
       return;
+   }
 
    //
    // Format the message into a QString:
@@ -93,67 +122,28 @@ void TextView::addMessage(const Message& message) {
    stream << message;
 
    //
-   // Get the foreground for the message level:
+   // Get the foreground/background color for the message level.
    //
-   std::map<Level, QColor>::const_iterator foreground_it;
-   if ((foreground_it = m_levelToForeground.find(message.getLevel())) ==
-       m_levelToForeground.end()) {
+   auto color_it = m_impl->m_levelColor.find(message.getLevel());
+   if (color_it == m_impl->m_levelColor.end()) {
       // There is something wrong with the level setting!
-      foreground_it = m_levelToForeground.find(INFO);
+      color_it = m_impl->m_levelColor.find(INFO);
    }
 
-   //
-   // Get the background for the message level:
-   //
-   std::map<Level, QColor>::const_iterator background_it;
-   if ((background_it = m_levelToBackground.find(message.getLevel())) ==
-       m_levelToBackground.end()) {
-      // There is something wrong with the level setting!
-      background_it = m_levelToBackground.find(INFO);
-   }
-
-   m_edit->setTextColor(foreground_it->second);
-   m_edit->setTextBackgroundColor(background_it->second);
-   m_edit->append(msg_text);
-
-   return;
+   // Add the message.
+   m_impl->m_edit.setTextBackgroundColor(color_it->second.first);
+   m_impl->m_edit.setTextColor(color_it->second.second);
+   m_impl->m_edit.append(msg_text);
 }
 
 void TextView::setMaximumMessageCount(int count) {
 
-   m_edit->document()->setMaximumBlockCount(count);
-   return;
+   m_impl->m_edit.document()->setMaximumBlockCount(count);
 }
 
 void TextView::setMinimumShownLevel(Level level) {
 
-   m_minShownLevel = level;
-   return;
-}
-
-/**
- * The class uses internal maps to color-code the messages based on
- * their message level. These maps are configured in this function.
- */
-void TextView::initMaps() {
-
-   m_levelToBackground[VERBOSE] = QColor(Qt::cyan);
-   m_levelToBackground[DEBUG] = QColor(Qt::blue);
-   m_levelToBackground[INFO] = QColor(Qt::white);
-   m_levelToBackground[WARNING] = QColor(Qt::yellow);
-   m_levelToBackground[ERROR] = QColor(Qt::red);
-   m_levelToBackground[FATAL] = QColor(Qt::darkRed);
-   m_levelToBackground[ALWAYS] = QColor(Qt::lightGray);
-
-   m_levelToForeground[VERBOSE] = QColor(Qt::black);
-   m_levelToForeground[DEBUG] = QColor(Qt::white);
-   m_levelToForeground[INFO] = QColor(Qt::black);
-   m_levelToForeground[WARNING] = QColor(Qt::black);
-   m_levelToForeground[ERROR] = QColor(Qt::white);
-   m_levelToForeground[FATAL] = QColor(Qt::white);
-   m_levelToForeground[ALWAYS] = QColor(Qt::black);
-
-   return;
+   m_impl->m_minShownLevel = level;
 }
 
 }  // namespace msg

--- a/gui/msg/TextView.h
+++ b/gui/msg/TextView.h
@@ -1,38 +1,26 @@
-// Dear emacs, this is -*- c++ -*-
+//
+// ATOMKI Common Data Acquisition
+//
+// (c) 2008-2025 ATOMKI, Debrecen, Hungary
+//
+// Apache License Version 2.0
+//
 #ifndef CDA_GUI_MSG_TEXTVIEW_H
 #define CDA_GUI_MSG_TEXTVIEW_H
-
-// STL include(s):
-#include <map>
-
-// Qt include(s):
-#include <QColor>
-#include <QWidget>
 
 // CDA include(s):
 #include "msg/Level.h"
 
-// Local include(s):
-#include "../common/Export.h"
+// Qt include(s).
+#include <QWidget>
 
-// Forward declaration(s):
-QT_FORWARD_DECLARE_CLASS(QStackedLayout)
-QT_FORWARD_DECLARE_CLASS(QTextEdit)
+// STL include(s):
+#include <memory>
 
 namespace msg {
 
 // Forward declaration(s):
 class Message;
-
-//
-// Make sure that the following Qt classes are available in the
-// msg namespace even if Qt has been built in an arbitrary
-// namespace:
-//
-using QT_PREPEND_NAMESPACE(QWidget);
-using QT_PREPEND_NAMESPACE(QStackedLayout);
-using QT_PREPEND_NAMESPACE(QTextEdit);
-using QT_PREPEND_NAMESPACE(QColor);
 
 /**
  *  @short Widget capable of showing messages
@@ -46,7 +34,7 @@ using QT_PREPEND_NAMESPACE(QColor);
  *
  * @author Attila Krasznahorkay <Attila.Krasznahorkay@cern.ch>
  */
-class CDAGUI_EXPORT TextView : public QWidget {
+class TextView : public QWidget {
 
    Q_OBJECT
 
@@ -70,18 +58,10 @@ public slots:
    void setMinimumShownLevel(Level level);
 
 private:
-   /// Function initialising the internal maps
-   void initMaps();
-
-   QStackedLayout* m_layout;  ///< The layout used by the widget
-   QTextEdit* m_edit;         ///< The text field showing the messages
-
-   /// Map to set the background of the messages
-   std::map<Level, QColor> m_levelToBackground;
-   /// Map to set the foreground of the messages
-   std::map<Level, QColor> m_levelToForeground;
-
-   Level m_minShownLevel;  ///< Level under which messages are not shown
+   /// Internal data type
+   struct Impl;
+   /// Internal data
+   std::unique_ptr<Impl> m_impl;
 
 };  // class TextView
 


### PR DESCRIPTION
Modernized `msg::TextView`. Apart from making it use PIMPL, it now behaves reasonably on Windows in dark mode.